### PR TITLE
Show time remaining before next votemode

### DIFF
--- a/lua/autobox/plugins/sh_votemode.lua
+++ b/lua/autobox/plugins/sh_votemode.lua
@@ -46,9 +46,9 @@ function PLUGIN:Call(ply)
 
         timer.Create("AAT_VoteModeEnd",10,1,function() PLUGIN:VoteEnd() end)
     else
-        local minutes = math.floor(self.cooldown / 60 % 60)
-        local seconds = math.floor(self.cooldown % 60)
-        autobox:Notify( ply, autobox.colors.red, "Please wait", autobox.colors.white,  minutes . ":" . seconds, autobox.colors.red, "before starting another mode vote." )
+        local minutes = math.floor((self.cooldown-CurTime()) / 60 % 60)
+        local seconds = math.floor((self.cooldown-CurTime()) % 60)
+        autobox:Notify( ply, autobox.colors.red, "Please wait", autobox.colors.white, " " .. minutes .. ":" .. seconds, autobox.colors.red, " before starting another mode vote." )
     end
 end
 

--- a/lua/autobox/plugins/sh_votemode.lua
+++ b/lua/autobox/plugins/sh_votemode.lua
@@ -46,7 +46,9 @@ function PLUGIN:Call(ply)
 
         timer.Create("AAT_VoteModeEnd",10,1,function() PLUGIN:VoteEnd() end)
     else
-        autobox:Notify( ply, autobox.colors.red, "Please wait longer before starting another mode vote." )
+        local minutes = math.floor(self.cooldown / 60 % 60)
+        local seconds = math.floor(self.cooldown % 60)
+        autobox:Notify( ply, autobox.colors.red, "Please wait", autobox.colors.white,  minutes . ":" . seconds, autobox.colors.red, "before starting another mode vote." )
     end
 end
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13711445/72756632-a9df6a80-3b82-11ea-8d73-dfbaa314f6d7.png)

Ignore the first two values, I've removed those (they were for testing). Only the minutes and seconds show up